### PR TITLE
Integrate prison roll logic and dialog

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
@@ -288,6 +288,24 @@ class GameBoardActivity : ComponentActivity() {
         }
     }
 
+    fun showRollPrisonDialog(dice1: Int, dice2: Int) {
+        runOnUiThread {
+            val dialog = android.app.AlertDialog.Builder(this)
+                .setTitle("Gefängniswurf")
+                .setMessage("Sie haben $dice1 und $dice2 geworfen.")
+                // close button just close the dialog
+                .setNeutralButton("OK") { _, _ ->
+                    Log.i("GameBoardActivity", "Dialog geschlossen.")
+                }
+                .create()
+            dialog.setCanceledOnTouchOutside(false)
+            dialog.setCancelable(false)
+            dialog.show()
+
+        }
+    }
+
+
     fun showPayPrisonDialog() {
         runOnUiThread {
             val dialog = android.app.AlertDialog.Builder(this)
@@ -304,6 +322,14 @@ class GameBoardActivity : ComponentActivity() {
                     )
                 }
                 .setNegativeButton("Nein") { _, _ ->
+                    val payload = GameController.buildPayload("playerId", myId)
+                    gameStomp.sendGameMessage(
+                        GameMessage(
+                            LobbyClient.lobbyId,
+                            GameMessageType.ROLL_PRISON,
+                            payload
+                        )
+                    )
                     Log.i("GameBoardActivity", "Zahlung abgebrochen.")
                 }
                 .create()

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
@@ -15,10 +15,12 @@ class GameClientHandler(
     private val activity: GameBoardActivity
 ) {
     fun handle(message: GameMessage) {
+        Log.i(TAG, "Message type: ${message.type}")
         when (message.type) {
             GameMessageType.GAME_STATE -> handleGameState(message.payload.asJsonObject)
             GameMessageType.ASK_BUY_PROPERTY -> handleAskBuyProperty(message.payload.asJsonObject)
             GameMessageType.ASK_PAY_PRISON -> handleAskPayPrison(message.payload.asJsonObject)
+            GameMessageType.ROLLED_PRISON -> handleRolledPrison(message.payload.asJsonObject)
             GameMessageType.DRAW_RISK_CARD,
             GameMessageType.DRAW_BANK_CARD -> handleEventCard(message.payload.asJsonObject)
             GameMessageType.PASS_START -> handlePassStart()
@@ -54,6 +56,18 @@ class GameClientHandler(
             activity.disableDiceButton()
         } else {
             Log.i(TAG, "Spieler $playerId möchte $tileName kaufen.")
+        }
+    }
+
+    private fun handleRolledPrison(payload: JsonObject) {
+        val playerId = payload["playerId"]?.asInt ?: return
+        val dice1 = payload["roll1"]?.asInt ?: return
+        val dice2 = payload["roll2"]?.asInt ?: return
+        if (playerId == LobbyClient.playerId) {
+            Log.i(TAG, "Spieler $playerId hat die Würfel $dice1 und $dice2 geworfen.")
+            activity.showRollPrisonDialog(dice1, dice2)
+        } else {
+            Log.i(TAG, "Spieler $playerId hat die Würfel $dice1 und $dice2 geworfen.")
         }
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/dto/GameMessageType.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/dto/GameMessageType.kt
@@ -8,6 +8,8 @@ enum class GameMessageType {
     BUY_PROPERTY,
     ASK_PAY_PRISON,
     PAY_PRISON,
+    ROLL_PRISON,
+    ROLLED_PRISON,
     PAY_RENT,
 
     PLAYER_MOVED,


### PR DESCRIPTION
This commit introduces functionality for handling prison rolls within the game.

Key changes include:

- **GameBoardActivity.kt:**
    - Added `showRollPrisonDialog()`: Displays a dialog to inform the player about their prison roll result.
    - Modified `showPayPrisonDialog()`: If the player chooses not to pay to get out of prison, a `ROLL_PRISON` message is now sent to the server.
- **GameClientHandler.kt:**
    - Added `handleRolledPrison()`: Processes the `ROLLED_PRISON` message from the server. If the message is for the current player, it calls `showRollPrisonDialog()` to display the roll result.
    - Updated the main `handle()` function to include the new `ROLLED_PRISON` message type.
- **GameMessageType.kt:**
    - Added `ROLL_PRISON` and `ROLLED_PRISON` to the enum of possible game message types.