### PR TITLE
Fix Lobby join bug

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/UsernameActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/UsernameActivity.kt
@@ -13,7 +13,7 @@ import at.aau.serg.websocketbrokerdemo.network.LobbyStomp
 class UsernameActivity : AppCompatActivity() {
 
     private lateinit var lobbyStomp: LobbyStomp
-    private lateinit var loginHandler: LoginHandler
+    private lateinit var noOpLobbyListener: NoOpLobbyListener
     private lateinit var usernameEditText: EditText
     private lateinit var enterButton: Button
 
@@ -24,8 +24,8 @@ class UsernameActivity : AppCompatActivity() {
         usernameEditText = findViewById(R.id.usernameEditText)
         enterButton = findViewById(R.id.enterButton)
 
-        loginHandler = LoginHandler(this)
-        lobbyStomp = LobbyStomp(loginHandler)
+        noOpLobbyListener = NoOpLobbyListener(this)
+        lobbyStomp = LobbyStomp(noOpLobbyListener)
         lobbyStomp.connect()
 
         enterButton.setOnClickListener {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/lobby/LoginHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/lobby/LoginHandler.kt
@@ -1,72 +1,16 @@
 package at.aau.serg.websocketbrokerdemo
 
-import android.content.Intent
-import android.util.Log
-import at.aau.serg.websocketbrokerdemo.lobby.LobbyClient
 import at.aau.serg.websocketbrokerdemo.network.LobbyMessageListener
 import at.aau.serg.websocketbrokerdemo.network.dto.LobbyDTO
 import at.aau.serg.websocketbrokerdemo.network.dto.PlayerDTO
-import com.google.gson.Gson
 import com.google.gson.JsonObject
 
-class LoginHandler(private val activity: UsernameActivity) : LobbyMessageListener {
-
+class NoOpLobbyListener(private val activity: UsernameActivity) : LobbyMessageListener {
     override fun onLobbyListUpdate(lobbies: List<LobbyDTO>) {
-        Log.i("LoginHandler", "Lobby update received: $lobbies")
-
-        val ownNickname = LobbyClient.username
-        val userLobby = lobbies.find { lobby ->
-            lobby.name.contains(ownNickname, ignoreCase = true)
-        }
-
-        if (userLobby != null) {
-            Log.i("LoginHandler", "User's lobby found: ${userLobby.name}, starting LobbyActivity")
-
-            val gson = Gson()
-            val lobbyJson = gson.toJson(userLobby)
-
-            val intent = Intent(activity, LobbyActivity::class.java).apply {
-                putExtra("lobby_json", lobbyJson)
-            }
-            activity.startActivity(intent)
-            activity.finish()
-        } else {
-            Log.i("LoginHandler", "User's lobby not found, ignoring update.")
-        }
     }
-
     override fun onLobbyUpdate(players: List<PlayerDTO>) {
-        Log.i("LoginHandler", "Lobby update received during login: $players")
-
-        val ownNickname = LobbyClient.username
-        val isOwnUserPresent = players.any { it.nickname == ownNickname }
-
-        if (isOwnUserPresent) {
-            Log.i("LoginHandler", "Nickname $ownNickname is in lobby, starting LobbyActivity")
-
-            LobbyClient.setPlayers(players)
-
-            // 🔧 Hier hinzufügen!
-            LobbyClient.playerId = players.firstOrNull { it.nickname == ownNickname }?.id ?: -1
-
-            val gson = Gson()
-            val playersJson = gson.toJson(players)
-
-            val intent = Intent(activity, LobbyActivity::class.java).apply {
-                putExtra("players_json", playersJson)
-            }
-            activity.startActivity(intent)
-            activity.finish()
-        } else {
-            Log.i("LoginHandler", "Own nickname $ownNickname not in list yet, ignoring update.")
-        }
     }
-
-
-
     override fun onStartGame(payload: JsonObject) {
-        // Ignoriere START_GAME-Nachricht während des Logins
-
     }
 
 }


### PR DESCRIPTION
The LoginHandler class has been renamed to NoOpLobbyListener.
The `onLobbyListUpdate` and `onLobbyUpdate` methods in this class now have empty implementations, as their previous logic was specific to the login process and is no longer needed in this context. The `onStartGame` method remains empty.

This change reflects that the listener is now a no-operation listener during the username input phase and does not actively handle lobby updates or game start events.