### PR TITLE
End Game logik and not being able to buy Streets

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
@@ -228,7 +228,20 @@ class GameBoardActivity : ComponentActivity() {
 
 
     fun showGameOverDialog(winnerName: String) {
-        showDialog("Spiel beendet, Gewinner", winnerName)
+        runOnUiThread {
+            android.app.AlertDialog.Builder(this)
+                .setTitle("Spiel beendet")
+                .setMessage("Der Gewinner ist $winnerName. Möchten Sie zum Lobby-Bildschirm zurückkehren?")
+                .setPositiveButton("Ja") { _, _ ->
+                    LobbyClient.lobbyId = -1 // Lobby-ID zurücksetzen
+                    LobbyClient.lobbyName = "" // Lobby-Name zurücksetzen
+                    LobbyClient.playerId = -1 // Spieler-ID zurücksetzen
+                    finish() // Schließt die Activity
+                }
+                .setNegativeButton("Nein", null)
+                .show()
+        }
+
     }
 
     fun showDialog(title: String, message: String) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
@@ -227,11 +227,11 @@ class GameBoardActivity : ComponentActivity() {
     }
 
 
-    fun showGameOverDialog(ranking: String) {
-        showDialog("Spiel beendet", ranking)
+    fun showGameOverDialog(winnerName: String) {
+        showDialog("Spiel beendet, Gewinner", winnerName)
     }
 
-    private fun showDialog(title: String, message: String) {
+    fun showDialog(title: String, message: String) {
         runOnUiThread {
             android.app.AlertDialog.Builder(this)
                 .setTitle(title)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ListLobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ListLobbyActivity.kt
@@ -73,8 +73,12 @@ class ListLobbyActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         Log.i("ListLobbyActivity", "onResume called")
-        // Request the list of lobbies when the activity is resumed
-        lobbyStomp.sendListLobbies()
+        // register before calling connect
+        lobbyStomp.setOnConnectedListener {
+            // this will only run once the socket is open
+            lobbyStomp.sendListLobbies()
+        }
+        lobbyStomp.connect()
     }
 
     private fun joinLobby(lobby: LobbyDTO) {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/ListLobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/ListLobbyActivity.kt
@@ -70,6 +70,13 @@ class ListLobbyActivity : ComponentActivity() {
 
     }
 
+    override fun onResume() {
+        super.onResume()
+        Log.i("ListLobbyActivity", "onResume called")
+        // Request the list of lobbies when the activity is resumed
+        lobbyStomp.sendListLobbies()
+    }
+
     private fun joinLobby(lobby: LobbyDTO) {
 
         playerId = LobbyClient.playerId

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
@@ -250,7 +250,7 @@ class GameClientHandler(
             Log.i(TAG, "Extra message for player $playerId, not showing to current player.")
             return
         }
-        activity.showDialog("Extra Message", message)
+        activity.showDialog(title, message)
     }
 
     companion object {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
@@ -31,6 +31,7 @@ class GameClientHandler(
             GameMessageType.CASH_TASK -> handleCashTask(message.payload.asJsonObject)
             GameMessageType.PLAYER_LOST -> handlePlayerLost(message.payload.asJsonObject)
             GameMessageType.GAME_OVER -> handleGameOver(message.payload.asJsonObject)
+            GameMessageType.EXTRA_MESSAGE -> handleExtraMessage(message.payload.asJsonObject)
             GameMessageType.ERROR -> Log.e(TAG, "Fehler: ${message.payload}")
             else -> Log.w(TAG, "Unbekannter Nachrichtentyp: ${message.type}")
         }
@@ -235,10 +236,21 @@ class GameClientHandler(
     }
 
     private fun handleGameOver(payload: JsonObject) {
-        val ranking = payload["ranking"]?.asJsonArray
-            ?.joinToString("\n") { it.asString }
-            ?: "Unbekannt"
-        activity.showGameOverDialog(ranking)
+        val winnerId = payload["winnerId"]?.asInt ?: return
+        val winnerName = payload["winnerName"]?.asString ?: return
+        activity.showGameOverDialog(winnerName)
+    }
+
+    private fun handleExtraMessage(payload: JsonObject) {
+        val playerId = payload["playerId"]?.asInt ?: return
+        val title = payload["title"]?.asString ?: "Extra Message"
+        val message = payload["message"]?.asString ?: return
+        Log.i(TAG, "Extra message: $message for player $playerId")
+        if (playerId != LobbyClient.playerId) {
+            Log.i(TAG, "Extra message for player $playerId, not showing to current player.")
+            return
+        }
+        activity.showDialog("Extra Message", message)
     }
 
     companion object {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/dto/GameMessageType.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/dto/GameMessageType.kt
@@ -11,6 +11,7 @@ enum class GameMessageType {
     ROLL_PRISON,
     ROLLED_PRISON,
     PAY_RENT,
+    EXTRA_MESSAGE,
 
     PLAYER_MOVED,
     CAN_BUY_PROPERTY,


### PR DESCRIPTION
This pull request introduces enhancements to the game logic and user interaction in the `GameBoardActivity` and `GameClientHandler` classes. Key changes include improving the handling of game-over scenarios, adding support for a new message type (`EXTRA_MESSAGE`), and refining dialog display logic.

### Enhancements to game logic:
* [`GameClientHandler.kt`](diffhunk://#diff-b326f8709196cd132c97b032209b04bdb33940a788e23441e7bd53c3b0fc8805L238-R253): Modified the `handleGameOver` method to use `winnerName` instead of a ranking list for the game-over dialog, improving clarity and user experience.
* [`GameMessageType.kt`](diffhunk://#diff-577b8c0b44d324a35d070f0af99680129e74bc4b4e31964caaecc910f020c2fcR14): Added a new message type, `EXTRA_MESSAGE`, to support additional player-specific messages.
* [`GameClientHandler.kt`](diffhunk://#diff-b326f8709196cd132c97b032209b04bdb33940a788e23441e7bd53c3b0fc8805L238-R253): Implemented a new `handleExtraMessage` method to process `EXTRA_MESSAGE` payloads, log details, and display a dialog to the relevant player.

### Improvements to user interaction:
* [`GameBoardActivity.kt`](diffhunk://#diff-cd393f889e3911ea8f974f2f06875c7529074bf57ced70721a045dadeaf861d5L230-R234): Updated the `showGameOverDialog` method to display the winner's name instead of a ranking string, making the dialog more specific and user-friendly.
* [`GameBoardActivity.kt`](diffhunk://#diff-cd393f889e3911ea8f974f2f06875c7529074bf57ced70721a045dadeaf861d5L230-R234): Made the `showDialog` method public, allowing it to be reused for displaying other types of dialogs, such as those triggered by `EXTRA_MESSAGE`.

### Issues
Fixes #27 for the end game. This is in combination with https://github.com/SE-Projekt-Beta/Server/pull/68 on the server.