### PR TITLE
Sync player token positions with game state

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameBoardActivity.kt
@@ -256,6 +256,10 @@ class GameBoardActivity : ComponentActivity() {
         }
     }
 
+    fun setPlayerTokenPosition(playerId: Int, position: Int) {
+        playerTokenManager.setPlayerTokenPosition(playerId, position)
+    }
+
     fun updateTokenPosition(steps: Int) {
         val currentPlayerId = GameStateClient.currentPlayerId
         playerTokenManager.movePlayerToken(currentPlayerId, steps)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/GameClientHandler.kt
@@ -98,6 +98,18 @@ class GameClientHandler(
         Log.i(TAG, "Players JSON: $playersJson")
         activity.updateTestView(playersJson)
 
+        // Update all player tokens based on their current position in the game state
+        try {
+            val gson = com.google.gson.Gson()
+            val type = object : com.google.gson.reflect.TypeToken<List<at.aau.serg.websocketbrokerdemo.game.PlayerClient>>() {}.type
+            val players: List<at.aau.serg.websocketbrokerdemo.game.PlayerClient> = gson.fromJson(playersJson, type)
+            players.forEach { player ->
+                activity.setPlayerTokenPosition(player.id, player.position)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update player tokens from playersJson", e)
+        }
+
         activity.updateTurnView(currentPlayerId, currentPlayerName)
         activity.updateTile(tileName, fieldIndex)
         activity.updateCashDisplay(cash)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManager.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManager.kt
@@ -86,4 +86,26 @@ class PlayerTokenManager(private val gameBoardActivity: GameBoardActivity) {
 
         player.position = newPosition
     }
+
+    // Set a player's token to an exact board position (used for syncing with game state)
+    fun setPlayerTokenPosition(playerId: Int, position: Int) {
+        val tileIndex = if (position % 40 == 0) 40 else position % 40
+        val tile = ClientBoardMap.getTile(tileIndex) ?: return
+
+        // Hole das Token des Spielers
+        val tokenIndex = playerIdToTokenIndex[playerId] ?: run {
+            Log.w("TokenDebug", "No token index found for playerId=$playerId")
+            return
+        }
+        val token = playerTokens.getOrNull(tokenIndex) ?: run {
+            Log.w("TokenDebug", "No token view found for index=$tokenIndex")
+            return
+        }
+        gameBoardActivity.runOnUiThread {
+            val scaledPos = scalePosition(tile.position!!)
+            token.x = scaledPos.x
+            token.y = scaledPos.y
+            Log.d("TokenDebug", "Set token for playerId=$playerId at scaled x=${scaledPos.x}, y=${scaledPos.y}")
+        }
+    }
 }


### PR DESCRIPTION
This commit introduces a mechanism to synchronize the visual positions of player tokens on the game board with their actual positions in the game state.

Specifically:
- Added `setPlayerTokenPosition` in `PlayerTokenManager` to directly set a player's token to a specific board position. This is used for syncing.
- In `GameClientHandler`, when player data is received, the `setPlayerTokenPosition` method is now called for each player to update their token's location on the UI.
- A corresponding `setPlayerTokenPosition` method was added to `GameBoardActivity` to facilitate the call from `GameClientHandler` to `PlayerTokenManager`.