### PR TITLE
Fix test failures

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManager.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManager.kt
@@ -59,7 +59,7 @@ class PlayerTokenManager(private val gameBoardActivity: GameBoardActivity) {
     // Funktion, um einen Spieler nach dem Würfeln zu verschieben
     fun movePlayerToken(playerId: Int, steps: Int) {
         val player = GameStateClient.players[playerId] ?: return
-        val newPosition = player.position % 40
+        val newPosition = (player.position + steps) % 40
         val tileIndex = if (newPosition == 0) 40 else newPosition
 
         val tile = ClientBoardMap.getTile(tileIndex) ?: return

--- a/app/src/test/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManagerTest.kt
+++ b/app/src/test/java/at/aau/serg/websocketbrokerdemo/game/PlayerTokenManagerTest.kt
@@ -72,6 +72,9 @@ class PlayerTokenManagerTest {
         val tileIndex = if (newPosition == 0) 40 else newPosition
         val newTile = ClientBoardMap.getTile(tileIndex)!!
 
+        // Initialize token mapping before moving
+        playerTokenManager.positionTokensOnStartTile()
+
         playerTokenManager.movePlayerToken(playerId, steps)
 
         verify { mockImageViews[0].x = newTile.position!!.x }


### PR DESCRIPTION
This commit ensures that the token mapping is initialized by calling `positionTokensOnStartTile()` before attempting to move a player token in the `movePlayerToken_movesPlayerTokenCorrectly` test.

Additionally, the calculation for `newPosition` in the `movePlayerToken` function of `PlayerTokenManager.kt` has been corrected to `(player.position + steps) % 40` to accurately reflect the player's new position after moving.